### PR TITLE
Add ssl support

### DIFF
--- a/src/R.MessageBus.Client.RabbitMQ/Consumer.cs
+++ b/src/R.MessageBus.Client.RabbitMQ/Consumer.cs
@@ -27,7 +27,7 @@ using ConsumerEventHandler = R.MessageBus.Interfaces.ConsumerEventHandler;
 
 namespace R.MessageBus.Client.RabbitMQ
 {
-    public class Consumer :  IConsumer
+    public class Consumer : IConsumer
     {
         private static readonly ILog Logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private readonly ITransportSettings _transportSettings;
@@ -210,6 +210,17 @@ namespace R.MessageBus.Client.RabbitMQ
                 connectionFactory.Password = _transportSettings.Password;
             }
 
+            if (_transportSettings.SslEnabled)
+            {
+                connectionFactory.Ssl = new SslOption
+                {
+                    Enabled = true,
+                    AcceptablePolicyErrors = _transportSettings.AcceptablePolicyErrors,
+                    ServerName = _transportSettings.ServerName
+                };
+                connectionFactory.Port = AmqpTcpEndpoint.DefaultAmqpSslPort;
+            }
+
             _connection = connectionFactory.CreateConnection();
 
             _model = _connection.CreateModel();
@@ -354,7 +365,7 @@ namespace R.MessageBus.Client.RabbitMQ
 
             try
             {
-                _model.ExchangeDeclare(retryDeadLetterExchangeName, "direct",  _durable, _autoDelete, null);
+                _model.ExchangeDeclare(retryDeadLetterExchangeName, "direct", _durable, _autoDelete, null);
             }
             catch (Exception ex)
             {
@@ -497,12 +508,12 @@ namespace R.MessageBus.Client.RabbitMQ
                     Logger.Debug("Disposing connection");
                     _connection.Dispose();
                 }
-                catch(System.IO.EndOfStreamException ex) 
+                catch (System.IO.EndOfStreamException ex)
                 {
                     Logger.Warn("Error disposing connection", ex);
                 }
                 _connection = null;
-            } 
+            }
         }
     }
 }

--- a/src/R.MessageBus.Client.RabbitMQ/Consumer.cs
+++ b/src/R.MessageBus.Client.RabbitMQ/Consumer.cs
@@ -76,7 +76,7 @@ namespace R.MessageBus.Client.RabbitMQ
         /// </summary>
         /// <param name="consumer"></param>
         /// <param name="args"></param>
-        public void Event(IBasicConsumer consumer, BasicDeliverEventArgs args)
+        public void Event(object consumer, BasicDeliverEventArgs args)
         {
             ConsumeEventResult result;
             IDictionary<string, object> headers = args.BasicProperties.Headers;
@@ -191,7 +191,7 @@ namespace R.MessageBus.Client.RabbitMQ
             var connectionFactory = new ConnectionFactory
             {
                 HostName = _hosts[_activeHost],
-                Protocol = Protocols.FromEnvironment(),
+                Protocol = Protocols.DefaultProtocol,
                 Port = AmqpTcpEndpoint.UseDefaultPort
             };
 
@@ -248,7 +248,7 @@ namespace R.MessageBus.Client.RabbitMQ
                 }
             }
 
-            var consumer = new EventingBasicConsumer();
+            var consumer = new EventingBasicConsumer(_model);
             consumer.Received += Event;
             if (_heartbeatEnabled)
             {

--- a/src/R.MessageBus.Client.RabbitMQ/Producer.cs
+++ b/src/R.MessageBus.Client.RabbitMQ/Producer.cs
@@ -51,7 +51,7 @@ namespace R.MessageBus.Client.RabbitMQ
             {
                 HostName = _hosts[_activeHost],
                 VirtualHost = "/",
-                Protocol = Protocols.FromEnvironment(),
+                Protocol = Protocols.DefaultProtocol,
                 Port = AmqpTcpEndpoint.UseDefaultPort
             };
 
@@ -93,13 +93,13 @@ namespace R.MessageBus.Client.RabbitMQ
             {
                 IBasicProperties basicProperties = _model.CreateBasicProperties();
 
-                basicProperties.Headers = GetHeaders(typeof (T), headers, _transportSettings.QueueName, "Publish");
+                basicProperties.Headers = GetHeaders(typeof(T), headers, _transportSettings.QueueName, "Publish");
                 basicProperties.MessageId = basicProperties.Headers["MessageId"].ToString(); // keep track of retries
 
                 basicProperties.SetPersistent(true);
                 var exchangeName = (null != baseType)
                     ? ConfigureExchange(baseType.FullName.Replace(".", string.Empty))
-                    : ConfigureExchange(typeof (T).FullName.Replace(".", string.Empty));
+                    : ConfigureExchange(typeof(T).FullName.Replace(".", string.Empty));
 
                 Retry.Do(() => _model.BasicPublish(exchangeName, _transportSettings.QueueName, basicProperties, bytes),
                     ex => RetryConnection(),
@@ -112,7 +112,7 @@ namespace R.MessageBus.Client.RabbitMQ
             {
                 MethodInfo publish = GetType().GetMethod("PublishBaseType", BindingFlags.NonPublic | BindingFlags.Instance);
                 MethodInfo genericPublish = publish.MakeGenericMethod(typeof(T), newBaseType);
-                genericPublish.Invoke(this, new object[] {message, headers});
+                genericPublish.Invoke(this, new object[] { message, headers });
             }
         }
 
@@ -220,7 +220,7 @@ namespace R.MessageBus.Client.RabbitMQ
         public void Dispose()
         {
             Logger.Debug("In Producer.Dispose()");
-            
+
             if (_model != null)
             {
                 Logger.Debug("Disposing Model");
@@ -240,7 +240,7 @@ namespace R.MessageBus.Client.RabbitMQ
                     Logger.Warn("Error disposing connection", ex);
                 }
                 _connection = null;
-            } 
+            }
         }
 
         public string Type

--- a/src/R.MessageBus.Client.RabbitMQ/Producer.cs
+++ b/src/R.MessageBus.Client.RabbitMQ/Producer.cs
@@ -65,6 +65,17 @@ namespace R.MessageBus.Client.RabbitMQ
                 _connectionFactory.Password = transportSettings.Password;
             }
 
+            if (_transportSettings.SslEnabled)
+            {
+                _connectionFactory.Ssl = new SslOption
+                {
+                    Enabled = true,
+                    AcceptablePolicyErrors = transportSettings.AcceptablePolicyErrors,
+                    ServerName = transportSettings.ServerName
+                };
+                _connectionFactory.Port = AmqpTcpEndpoint.DefaultAmqpSslPort;
+            }
+
             CreateConnection();
         }
 

--- a/src/R.MessageBus.Client.RabbitMQ/R.MessageBus.Client.RabbitMQ.csproj
+++ b/src/R.MessageBus.Client.RabbitMQ/R.MessageBus.Client.RabbitMQ.csproj
@@ -51,8 +51,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client">
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=3.5.3.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\packages\RabbitMQ.Client.3.5.3\lib\net40\RabbitMQ.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/R.MessageBus.Client.RabbitMQ/packages.config
+++ b/src/R.MessageBus.Client.RabbitMQ/packages.config
@@ -3,5 +3,5 @@
   <package id="Common.Logging" version="3.0.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net40" />
+  <package id="RabbitMQ.Client" version="3.5.3" targetFramework="net45" />
 </packages>

--- a/src/R.MessageBus.Interfaces/ITransportSettings.cs
+++ b/src/R.MessageBus.Interfaces/ITransportSettings.cs
@@ -15,6 +15,7 @@
 //Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 using System.Collections.Generic;
+using System.Net.Security;
 
 namespace R.MessageBus.Interfaces
 {
@@ -80,5 +81,25 @@ namespace R.MessageBus.Interfaces
         string QueueName { get; set; }
 
         bool PurgeQueueOnStartup { get; set; }
+
+        /// <summary>
+        /// Communicate over AMQPS instead of AMQP?
+        /// See also <see cref="AcceptablePolicyErrors">AcceptablePolicyErrors</see>
+        /// See also <see cref="ServerName">ServerName</see>
+        /// </summary>
+        bool SslEnabled { get; set; }
+
+        /// <summary>
+        /// Used during server certificate validation. Useful mainly for development purposes.
+        /// In production, this should be left to <see cref="SslPolicyErrors.None">SslPolicyErrors.None</see> (default)
+        /// </summary>
+        SslPolicyErrors AcceptablePolicyErrors { get; set; }
+
+        /// <summary>
+        /// Used during SSL validation.
+        /// If set, it must match exactly with Canonical Name (CN) of the certificate.
+        /// Useful for wildcard certificates where rabbitmq factory will fail to validate ssl certificate otherwise.
+        /// </summary>
+        string ServerName { get; set; }
     }
 }

--- a/src/R.MessageBus.Settings/TransportSettings.cs
+++ b/src/R.MessageBus.Settings/TransportSettings.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using R.MessageBus.Interfaces;
+using System.Net.Security;
 
 namespace R.MessageBus.Settings
 {
@@ -35,5 +36,8 @@ namespace R.MessageBus.Settings
         public bool DisableErrors { get; set; }
         public string HeartbeatQueueName { get; set; }
         public IDictionary<string, object> ClientSettings { get; set; }
+        public bool SslEnabled { get; set; }
+        public SslPolicyErrors AcceptablePolicyErrors { get; set; }
+        public string ServerName { get; set; }
     }
 }


### PR DESCRIPTION
RabbitMQ.Client had to be updated in order to be able to use the newer elliptical curve key certificate (that my host is using)

Tested with my own server (based off ECDHE-RSA-AES256-SHA384 cipher setting [as reported by openssl - rabbit server is 3.5.1 running off erlang 17.5 on a gentoo host] connection setup)

If there's anything else I need to do get this accepted, please feel free to drop me a shout.